### PR TITLE
AdServerService to enrich openrtb2's responses

### DIFF
--- a/src/main/java/org/prebid/server/auction/AdServerService.java
+++ b/src/main/java/org/prebid/server/auction/AdServerService.java
@@ -1,0 +1,13 @@
+package org.prebid.server.auction;
+
+import com.iab.openrtb.request.BidRequest;
+import io.vertx.core.Future;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.Map;
+
+public interface AdServerService {
+
+    Future<Map<String, String>> buildAdServerKeyValues(RoutingContext context, BidRequest request);
+
+}

--- a/src/main/java/org/prebid/server/auction/ExchangeService.java
+++ b/src/main/java/org/prebid/server/auction/ExchangeService.java
@@ -69,10 +69,9 @@ public class ExchangeService {
     private long expectedCacheTime;
     private final ExchangeServiceMetrics serviceMetrics;
 
-    public ExchangeService(BidderCatalog bidderCatalog,
-                           ResponseBidValidator responseBidValidator, CacheService cacheService,
-                           AdServerService adServerService, ExchangeServiceMetrics serviceMetrics,
-                           Clock clock, long expectedCacheTime) {
+    public ExchangeService(BidderCatalog bidderCatalog, ResponseBidValidator responseBidValidator,
+                           AdServerService adServerService, CacheService cacheService,
+                           ExchangeServiceMetrics serviceMetrics, Clock clock, long expectedCacheTime) {
         this.bidderCatalog = Objects.requireNonNull(bidderCatalog);
         this.responseBidValidator = Objects.requireNonNull(responseBidValidator);
         this.adServerService = Objects.requireNonNull(adServerService);
@@ -117,15 +116,13 @@ public class ExchangeService {
 
         final long startTime = clock.millis();
 
-        // retrieve adServerService key values
-        Future<Map<String, String>> adServerKeyValues = Future.future();
-
-        // send all the requests to the bidders and gathers results
+        // prepare the future to send all the requests to the bidders and gathers results
         final CompositeFuture bidderResults = CompositeFuture.join(bidderRequests.stream()
                 .map(bidderRequest -> requestBids(bidderRequest, startTime,
                         auctionTimeout(timeout, shouldCacheBids), aliases))
                 .collect(Collectors.toList()));
 
+        // request all the bidders and also retrieve adServerService key values
         CompositeFuture all = CompositeFuture.all(bidderResults,
                 adServerService.buildAdServerKeyValues(context, bidRequest));
 

--- a/src/main/java/org/prebid/server/auction/NoOpAdServerService.java
+++ b/src/main/java/org/prebid/server/auction/NoOpAdServerService.java
@@ -1,0 +1,17 @@
+package org.prebid.server.auction;
+
+import com.iab.openrtb.request.BidRequest;
+import io.vertx.core.Future;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class NoOpAdServerService implements AdServerService {
+
+    @Override
+    public Future<Map<String, String>> buildAdServerKeyValues(RoutingContext context, BidRequest request) {
+        return Future.succeededFuture(Collections.EMPTY_MAP);
+    }
+
+}

--- a/src/main/java/org/prebid/server/handler/openrtb2/AuctionHandler.java
+++ b/src/main/java/org/prebid/server/handler/openrtb2/AuctionHandler.java
@@ -68,7 +68,7 @@ public class AuctionHandler implements Handler<RoutingContext> {
         auctionRequestFactory.fromRequest(context)
                 .recover(this::updateErrorRequestsMetric)
                 .map(bidRequest -> updateAppAndNoCookieMetrics(bidRequest, uidsCookie.hasLiveUids(), isSafari))
-                .compose(bidRequest -> exchangeService.holdAuction(bidRequest, uidsCookie,
+                .compose(bidRequest -> exchangeService.holdAuction(context, bidRequest, uidsCookie,
                         timeout(bidRequest, startTime)))
                 .setHandler(responseResult -> handleResult(responseResult, context));
     }

--- a/src/main/java/org/prebid/server/proto/openrtb/ext/response/ExtBidResponse.java
+++ b/src/main/java/org/prebid/server/proto/openrtb/ext/response/ExtBidResponse.java
@@ -29,4 +29,6 @@ public class ExtBidResponse {
      * Defines the contract for bidresponse.ext.usersync
      */
     Map<String, ExtResponseSyncData> usersync;
+
+    Map<String, String> adserverkeyvalues;
 }

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -5,10 +5,12 @@ import de.malkusch.whoisServerList.publicSuffixList.PublicSuffixListFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
+import org.prebid.server.auction.AdServerService;
 import org.prebid.server.auction.AmpRequestFactory;
 import org.prebid.server.auction.AuctionRequestFactory;
 import org.prebid.server.auction.ExchangeService;
 import org.prebid.server.auction.ImplicitParametersExtractor;
+import org.prebid.server.auction.NoOpAdServerService;
 import org.prebid.server.auction.PreBidRequestContextFactory;
 import org.prebid.server.auction.StoredRequestProcessor;
 import org.prebid.server.bidder.BidderCatalog;
@@ -122,13 +124,18 @@ public class ServiceConfiguration {
     }
 
     @Bean
+    AdServerService adServerService() {
+        return new NoOpAdServerService();
+    }
+
+    @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     ExchangeService exchangeService(
             @Value("${auction.expected-cache-time-ms}") long expectedCacheTimeMs,
             BidderCatalog bidderCatalog, ResponseBidValidator responseBidValidator,
-            CacheService cacheService, Metrics metrics, Clock clock) {
+            AdServerService adServerService, CacheService cacheService, Metrics metrics, Clock clock) {
 
-        return new ExchangeService(bidderCatalog, responseBidValidator, cacheService, metrics, clock,
+        return new ExchangeService(bidderCatalog, responseBidValidator, adServerService, cacheService, metrics, clock,
                 expectedCacheTimeMs);
     }
 

--- a/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
+++ b/src/main/java/org/prebid/server/spring/config/ServiceConfiguration.java
@@ -134,9 +134,9 @@ public class ServiceConfiguration {
     @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     ExchangeService exchangeService(
-            @Value("${auction.expected-cache-time-ms}") long expectedCacheTimeMs,
-            BidderCatalog bidderCatalog, ResponseBidValidator responseBidValidator,
-            AdServerService adServerService,CacheService cacheService, ExchangeServiceMetrics exchangeServiceMetrics, Clock clock) {
+            @Value("${auction.expected-cache-time-ms}") long expectedCacheTimeMs, BidderCatalog bidderCatalog,
+            ResponseBidValidator responseBidValidator, AdServerService adServerService, CacheService cacheService,
+            ExchangeServiceMetrics exchangeServiceMetrics, Clock clock) {
 
         return new ExchangeService(bidderCatalog, responseBidValidator, adServerService, cacheService,
                 exchangeServiceMetrics, clock, expectedCacheTimeMs);

--- a/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
+++ b/src/test/java/org/prebid/server/auction/ExchangeServiceTest.java
@@ -104,7 +104,6 @@ public class ExchangeServiceTest extends VertxTest {
     @Mock
     private AdServerService adServerService;
 
-
     private Clock clock;
     private Timeout timeout;
     private ExchangeService exchangeService;

--- a/src/test/java/org/prebid/server/handler/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/AuctionHandlerTest.java
@@ -559,7 +559,7 @@ public class AuctionHandlerTest extends VertxTest {
     @Test
     public void shouldIncrementSafariAndNoCookieMetrics() {
         // given
-        givenPreBidRequestContext(identity(), builder -> builder.noLiveUids(true));
+        PreBidRequestContext preBidRequestContext = givenPreBidRequestContext(identity(), builder -> builder.noLiveUids(true));
 
         httpRequest.headers().add(HttpHeaders.USER_AGENT, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) " +
                 "AppleWebKit/601.7.7 (KHTML, like Gecko) Version/9.1.2 Safari/601.7.7");
@@ -568,6 +568,9 @@ public class AuctionHandlerTest extends VertxTest {
         auctionHandler.handle(routingContext);
 
         // then
+        verify(handlerMetrics).updateRequestMetrics(routingContext, auctionHandler);
+        verify(handlerMetrics).updateAppAndNoCookieMetrics(routingContext, auctionHandler, preBidRequestContext, true,
+                false);
         verify(metrics).incCounter(eq(MetricName.safari_requests));
         verify(metrics).incCounter(eq(MetricName.no_cookie_requests));
         verify(metrics).incCounter(eq(MetricName.safari_no_cookie_requests));
@@ -615,6 +618,7 @@ public class AuctionHandlerTest extends VertxTest {
         auctionHandler.handle(routingContext);
 
         // then
+        verify(handlerMetrics).bidResponseOrError(any());
         verify(adapterMetrics).incCounter(eq(MetricName.error_requests));
         verify(accountAdapterMetrics).incCounter(eq(MetricName.error_requests));
     }

--- a/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
@@ -99,7 +99,7 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willThrow(new RuntimeException("Unexpected exception"));
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willThrow(new RuntimeException("Unexpected exception"));
 
         // when
         auctionHandler.handle(routingContext);
@@ -115,14 +115,14 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willReturn(
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
                 Future.succeededFuture(BidResponse.builder().build()));
 
         // when
         auctionHandler.handle(routingContext);
 
         // then
-        verify(exchangeService).holdAuction(any(), any(), any());
+        verify(exchangeService).holdAuction(any(), any(), any(), any());
         verify(httpResponse).putHeader(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
         verify(httpResponse).end(eq("{}"));
     }
@@ -133,7 +133,7 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().tmax(1000L).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willReturn(
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
                 Future.succeededFuture(BidResponse.builder().build()));
 
         // when
@@ -149,7 +149,7 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willReturn(
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
                 Future.succeededFuture(BidResponse.builder().build()));
 
         // when
@@ -165,7 +165,7 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().tmax(1000L).build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willReturn(
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
                 Future.succeededFuture(BidResponse.builder().build()));
 
         final Instant now = Instant.now();
@@ -240,13 +240,13 @@ public class AuctionHandlerTest extends VertxTest {
         given(auctionRequestFactory.fromRequest(any()))
                 .willReturn(Future.succeededFuture(BidRequest.builder().build()));
 
-        given(exchangeService.holdAuction(any(), any(), any())).willReturn(
+        given(exchangeService.holdAuction(any(), any(), any(), any())).willReturn(
                 Future.succeededFuture(BidResponse.builder().build()));
     }
 
     private Timeout captureTimeout() {
         final ArgumentCaptor<Timeout> timeoutCaptor = ArgumentCaptor.forClass(Timeout.class);
-        verify(exchangeService).holdAuction(any(), any(), timeoutCaptor.capture());
+        verify(exchangeService).holdAuction(any(), any(), any(), timeoutCaptor.capture());
         return timeoutCaptor.getValue();
     }
 }

--- a/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
+++ b/src/test/java/org/prebid/server/handler/openrtb2/AuctionHandlerTest.java
@@ -37,7 +37,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class AuctionHandlerTest extends VertxTest {
 

--- a/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/test-auction-response.json
+++ b/src/test/resources/org/prebid/server/ApplicationTest/openrtb2/test-auction-response.json
@@ -1020,6 +1020,7 @@
       "adform": "{{ adform.response_time_ms }}",
       "sovrn": "{{ sovrn.response_time_ms }}",
       "adtelligent": "{{ adtelligent.response_time_ms }}"
-    }
+    },
+    "adserverkeyvalues" : {}
   }
 }


### PR DESCRIPTION
We considered extending/wrapping ExchangeService but in the end AmpHandler uses its EXT_BID_RESPONSE_TYPE_REFERENCE to map ExtBidResponse. To overcome this we could also have extracted that TypeRefence to make it configurable but in the end we are "affraid of" having problems with this Lombok class because of inheritance (ExtBidResponse -> MarfeelExtBidReponse) (https://reinhard.codes/2015/09/16/lomboks-builder-annotation-and-inheritance/), so we finally decided to create a new component and add a new field into ExtBidResponse

- BidReponse.ext field, which is "mapped" from/to ExtBidResponse, now has a new field adserverkeyvalues
- AdServerService will fill this new field based on BidRequest and RoutingContext(thus we can read/parse custom query params). We have provided a noop impl
- AmpHandler in the last step adds this new key-values from the adServerService to targeting map